### PR TITLE
修复idlebeat路由无法处理到的bug

### DIFF
--- a/src/DotXxlJob.Core/XxlRestfulServiceHandler.cs
+++ b/src/DotXxlJob.Core/XxlRestfulServiceHandler.cs
@@ -71,7 +71,7 @@ namespace DotXxlJob.Core
                     case "beat":
                         ret = Beat();
                         break;
-                    case "idleBeat":
+                    case "idlebeat":
                         ret = IdleBeat(JsonConvert.DeserializeObject<IdleBeatRequest>(json));
                         break;
                     case "run":


### PR DESCRIPTION
因为 var method = arrParts[arrParts.Length - 1].ToLower(); 已经转成小写了，这个switch里边的也应该是小写才对