### PR TITLE
Update XxlRestfulServiceHandler.cs

### DIFF
--- a/src/DotXxlJob.Core/XxlRestfulServiceHandler.cs
+++ b/src/DotXxlJob.Core/XxlRestfulServiceHandler.cs
@@ -106,7 +106,7 @@ namespace DotXxlJob.Core
             {
                 bodyText = await reader.ReadToEndAsync();
             }
-            return bodyText;
+            return bodyText??string.Emppty;
         }
 
         #region rpc service


### PR DESCRIPTION
bodyText（没有任务参数）为空时会出错